### PR TITLE
unable to make an executable on windows with "./makewin64" in package.json

### DIFF
--- a/makewin32.js
+++ b/makewin32.js
@@ -6,7 +6,7 @@ if (fs.existsSync('build/Node-RED-win32-ia32')) {
     console.log("Building setup app for Windows 32bit");
     resultPromise = electronInstaller.createWindowsInstaller({
         appDirectory: 'build/Node-RED-win32-ia32',
-        outputDirectory: '../electron-bin/',
+        outputDirectory: 'executable/electron-win32-ia32/',
         authors: 'IBM Corp.',
         exe: 'Node-RED.exe',
         setupExe: 'Node-RED-Electron-ia32.exe',

--- a/makewin64.js
+++ b/makewin64.js
@@ -6,7 +6,7 @@ if (fs.existsSync('build/Node-RED-win32-x64')) {
     console.log("Building setup app for Windows 64bit");
     resultPromise = electronInstaller.createWindowsInstaller({
         appDirectory: 'build/Node-RED-win32-x64',
-        outputDirectory: '../electron-bin/',
+        outputDirectory: 'executable/electron-win32-x64/',
         authors: 'IBM Corp.',
         exe: 'Node-RED.exe',
         setupExe: 'Node-RED-Electron-x64.exe',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "electron-node-red",
+    "name": "electron_node_red",
     "version": "0.17.4",
     "description": "Electron Node-RED application starter",
     "main": "main.js",
@@ -14,8 +14,8 @@
         "pack:osx": "electron-packager . Node-RED --icon=nodered.icns --platform=darwin --arch=x64 --out=build --overwrite",
         "pack:linux32": "electron-packager . Node-RED --icon=nodered.icns --platform=linux --arch=ia32 --out=build --overwrite && cp afterinst.sh build/Node-RED-linux-ia32/",
         "pack:linux64": "electron-packager . Node-RED --icon=nodered.icns --platform=linux --arch=x64 --out=build --overwrite && cp afterinst.sh build/Node-RED-linux-x64",
-        "pack:win32": "electron-packager . Node-RED --icon=nodered.icns --platform=win32 --arch=ia32 --out=build --asar=true --overwrite --win32metadata.CompanyName='IBM Corp.' --win32metadata.ProductName='Node-RED Electron'",
-        "pack:win64": "electron-packager . Node-RED --icon=nodered.icns --platform=win32 --arch=x64  --out=build --asar=true --overwrite --win32metadata.CompanyName='IBM Corp.' --win32metadata.ProductName='Node-RED Electron'",
+        "pack:win32": "electron-packager . Node-RED --icon=nodered.icns --platform=win32 --arch=ia32 --out=build --asar --overwrite --win32metadata.CompanyName='IBM Corp.' --win32metadata.ProductName='Node-RED Electron'",
+        "pack:win64": "electron-packager . Node-RED --icon=nodered.icns --platform=win32 --arch=x64  --out=build --asar --overwrite --win32metadata.CompanyName='IBM Corp.' --win32metadata.ProductName='Node-RED Electron'",
         "pack:armv7l": "electron-packager . Node-RED --icon=nodered.icns --platform=linux --arch=armv7l --out=build --overwrite && cp afterinst.sh build/Node-RED-linux-armv7l",
 
         "build": "npm run clean && npm run build:osx && npm run build:linux64 && npm run build:linux32",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "electron-node-red",
+    "name": "electron_node_red",
     "version": "0.17.4",
     "description": "Electron Node-RED application starter",
     "main": "main.js",
@@ -22,8 +22,8 @@
         "build:osx": "npm run pack:osx && appdmg appdmg.json ../electron-bin/Node-RED-Electron_$npm_package_version.dmg",
         "build:linux32": "npm run pack:linux32 && fpm -s dir -t deb -f -n node-red-electron -v $npm_package_version -m conway@uk.ibm.com -a i386   -p ../electron-bin -C build/Node-RED-linux-ia32 --prefix=/opt/node-red --after-install=afterinst.sh ./",
         "build:linux64": "npm run pack:linux64 && fpm -s dir -t deb -f -n node-red-electron -v $npm_package_version -m conway@uk.ibm.com -a x86_64 -p ../electron-bin -C build/Node-RED-linux-x64  --prefix=/opt/node-red --after-install=afterinst.sh ./",
-        "build:win32": "npm run pack:win32 && ./makewin32.js",
-        "build:win64": "npm run pack:win64 && ./makewin64.js",
+        "build:win32": "npm run pack:win32 && node makewin32.js",
+        "build:win64": "npm run pack:win64 && node makewin64.js",
         "build:armv7l": "npm run pack:armv7l && fpm -s dir -t deb -f -n node-red-electron -v $npm_package_version -m conway@uk.ibm.com -a armv7l -p ../electron-bin -C build/Node-RED-linux-armv7l --prefix=/opt/node-red --after-install=afterinst.sh ./"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "electron_node_red",
+    "name": "electron-node-red",
     "version": "0.17.4",
     "description": "Electron Node-RED application starter",
     "main": "main.js",


### PR DESCRIPTION
Fixing the package.json making the commands "npm run build:win32" and "npm run build:win64" to fail on windows. Changing the output directory of the makewin32.js and makewin64.js, to output in the source folder.